### PR TITLE
Mark project as deprecated and update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-# What is this?
+# Deprecated
 
-It's a personal blog service by @mahata. It's served at [https://vercelog.mahata.org](https://vercelog.mahata.org/)
-
-## Tweak it locally
-
-It's nice to make sure your change doesn't break anything. The best way to do this is to set up a local pre-commit hook like this:
-
-```
-mkdir -p .git/hooks
-echo "make pre-commit" > .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
+It's replaced by: https://github.com/mahata-pages/mahata-pages.github.io


### PR DESCRIPTION
This pull request updates the `README.md` to indicate that the project is now deprecated and has been replaced by a new repository.

Documentation update:

* Updated `README.md` to state that the project is deprecated and now replaced by `https://github.com/mahata-pages/mahata-pages.github.io`, removing previous setup and usage instructions.Updated README to indicate deprecation and provide new link.